### PR TITLE
Add the `log.txt` API endpoint

### DIFF
--- a/src/tech/usb-web-interface.rst
+++ b/src/tech/usb-web-interface.rst
@@ -82,6 +82,21 @@ Upload a document to the last folder that was listed.
     -H 'Connection: keep-alive' \
     -F "file=@$file;filename=$(basename "$file");type=application/pdf"
 
+``GET http://10.11.99.1/log.txt``
+---------------------------------
+
+Download the device's systemd journal entries as a log file.
+
+**Example:**
+
+.. code:: bash
+
+  curl \
+    --silent \
+    --remote-name \
+    --remote-header-name \
+    'http://10.11.99.1/log.txt'
+
 External links
 ==============
 

--- a/src/tech/usb-web-interface.rst
+++ b/src/tech/usb-web-interface.rst
@@ -85,7 +85,7 @@ Upload a document to the last folder that was listed.
 ``GET http://10.11.99.1/log.txt``
 ---------------------------------
 
-Download the device's systemd journal entries as a log file.
+Download the xochitl log file found at ``/home/root/log.txt``.
 
 **Example:**
 


### PR DESCRIPTION
This PR adds the `GET /log.txt` API endpoint to the USB web interface documentation.

There are some more endpoints that I saw when reversing Xochitl that I don't see documented here - off the top of my head, I think I glanced at `/search`. I'll take a deeper look at them at some point and document those too.