### PR TITLE
Includes new .rmdoc file information for USB-Web-interface and the specific API call

### DIFF
--- a/src/tech/usb-web-interface.rst
+++ b/src/tech/usb-web-interface.rst
@@ -64,6 +64,19 @@ Download the PDF for a specific document.
   curl \
     -I "http://10.11.99.1/download/$guid/placeholder"
 
+``GET http://10.11.99.1/download/{guid}/rmdoc``
+---------------------------------
+
+Download the raw notebook file(.rmdoc) for a specific document.(New in version 3.10)
+
+**Example:**
+
+.. code:: bash
+
+  guid=fd2c4b2c-3849-46c3-bf2d-9c80994cc985
+  curl \
+    -I "http://10.11.99.1/download/$guid/rmdoc"
+
 ``POST http://10.11.99.1/upload``
 ---------------------------------
 

--- a/src/tech/usb-web-interface.rst
+++ b/src/tech/usb-web-interface.rst
@@ -67,7 +67,7 @@ Download the PDF for a specific document.
 ``GET http://10.11.99.1/download/{guid}/rmdoc``
 -----------------------------------------------
 
-Download the raw notebook file(.rmdoc) for a specific document.(From v3.9)
+Download the raw notebook archive for a specific document. This was added in v3.9.
 
 **Example:**
 

--- a/src/tech/usb-web-interface.rst
+++ b/src/tech/usb-web-interface.rst
@@ -65,7 +65,7 @@ Download the PDF for a specific document.
     -I "http://10.11.99.1/download/$guid/placeholder"
 
 ``GET http://10.11.99.1/download/{guid}/rmdoc``
----------------------------------
+-----------------------------------------------
 
 Download the raw notebook file(.rmdoc) for a specific document.(New in version 3.10)
 

--- a/src/tech/usb-web-interface.rst
+++ b/src/tech/usb-web-interface.rst
@@ -67,7 +67,7 @@ Download the PDF for a specific document.
 ``GET http://10.11.99.1/download/{guid}/rmdoc``
 -----------------------------------------------
 
-Download the raw notebook file(.rmdoc) for a specific document.(New in version 3.10)
+Download the raw notebook file(.rmdoc) for a specific document.(From v3.9)
 
 **Example:**
 


### PR DESCRIPTION
From the latest 3.10 beta, the ability to download .rmdoc notebook archives was added to the web-interface. It seems to work quite similar to the PDF download option, but instead of `/placeholder`, it uses `/rmdoc`