### PR TITLE
Fix not empy passphrase in the ssh-keygen command for windows cmd

### DIFF
--- a/src/guide/access/ssh.rst
+++ b/src/guide/access/ssh.rst
@@ -168,7 +168,7 @@ The following command will generate a private and public SSH key pair:
 
     ssh-keygen ^
       -f %userprofile%\.ssh\id_rsa_remarkable ^
-      -N ''
+      -N ""
 
   .. code-tab:: pwsh Windows (PowerShell)
 


### PR DESCRIPTION
The command currently is being parsed as string literals and resulting in a passphrase of `''` and not empty. This pull request replaces the command flag with `-N ""` which correctly creates the empty passphrase. I've tested this new command locally.