### PR TITLE
Update backlight file

### DIFF
--- a/src/devel/device/display.rst
+++ b/src/devel/device/display.rst
@@ -47,10 +47,10 @@ Adjusting programmatically
 Setting the brightness outside of the range you can select in xochitl will make the battery drain faster, and may have unintended side effects that could damage the device.
 :raw-html:`</div>`
 
-The backlight can also be adjusted programmatically by writing to the `/sys/class/backlight/backlight/brightness` file.
+The backlight can also be adjusted programmatically by writing to the `/sys/class/backlight/rm_frontlight/brightness` file.
 The value written to this file should be between 0 and 2047, where 0 is completely off and 2047 is the maximum brightness.
 
 .. code-block:: shell
 
-  echo 1734 > /sys/class/backlight/backlight/brightness
+  echo 1734 > /sys/class/backlight/rm_frontlight/brightness
 


### PR DESCRIPTION
The file to change display's backlight on paper pro was incorrect. 

Also, the presets' percentages are not totally accurate as the scale is non-linear but it doesn't seem important enough to change.
- `cat /sys/class/backlight/rm_frontlight/scale` returns `non-linear`
- `cat /sys/class/backlight/rm_frontlight/linear_mapping` returns `no`

extra note:
`cat /sys/class/backlight/rm_frontlight/device/name` returns `aw99703` and a [datasheet](https://www.awinic.com/en/productDetail/AW99703CSR)  I found online says it's an lcd backlight controller with 11bit dimming (0-2047) and linear or exponential control modes so it might be using the latter