### PR TITLE
FAQ: added note explaining `umount -R` and `/etc/dropbear`

### DIFF
--- a/src/faqs.rst
+++ b/src/faqs.rst
@@ -155,7 +155,15 @@ If you need to make a change to a folder that is mounted as an overlay, you can 
 
 .. code-block:: shell
 
-  umount -l /etc
+  umount -R /etc
+
+    Note: this command will unmount ``/etc/dropbear`` before unmounting ``/etc``. The ``/etc/dropbear`` directory is a "bind-mount" to ``/home/root/.dropbear``, which contains the tablet's SSH host keys. (This is why the rMPP's SSH host keys don't change when the OS is upgraded.)
+
+    If you need to be able to SSH into the tablet while the ``/etc`` overlay is un-mounted, you should mount ``/etc/dropbear`` again, the way it normally is:
+
+    .. code-block:: shell
+
+    mount -t bind /home/root/.dropbear /etc/dropbear
 
 To see a full list of folders that have overlays you can run the following command:
 
@@ -170,7 +178,8 @@ If you don't want to reboot, you can set the filesystems back to their normal st
 .. code-block:: shell
 
   mount -o remount,ro /
+  umount /etc/dropbear
   mount -o rw,relatime,lowerdir=/etc,upperdir=/var/volatile/etc,workdir=/var/volatile/.etc-work -t overlay overlay /etc
-  mount -o bind /home/root/.dropbear /etc/dropbear
+  mount -t bind /home/root/.dropbear /etc/dropbear
 
-Note that you can get the value of the `-o` option in the second command by running the `mount | grep overlay` command noted above, *before* un-mounting anything.
+Note that you can get the value of the ``-o`` option in the second ``mount`` command by running the ``mount | grep overlay`` command noted above, *before* un-mounting anything.

--- a/src/faqs.rst
+++ b/src/faqs.rst
@@ -151,19 +151,12 @@ To make the root filesystem read-write:
 
    mount -o remount,rw /
 
-If you need to make a change to a folder that is mounted as an overlay, you can just unmount the overlay. For example:
+If you need to make a change to a folder that is mounted as an overlay, you can just unmount the overlay (and remount the ssh host keys so you will be able to reconnect). For example:
 
 .. code-block:: shell
 
   umount -R /etc
-
-    Note: this command will unmount ``/etc/dropbear`` before unmounting ``/etc``. The ``/etc/dropbear`` directory is a "bind-mount" to ``/home/root/.dropbear``, which contains the tablet's SSH host keys. (This is why the rMPP's SSH host keys don't change when the OS is upgraded.)
-
-    If you need to be able to SSH into the tablet while the ``/etc`` overlay is un-mounted, you should mount ``/etc/dropbear`` again, the way it normally is:
-
-    .. code-block:: shell
-
-    mount -t bind /home/root/.dropbear /etc/dropbear
+  mount -t bind /home/root/.dropbear /etc/dropbear
 
 To see a full list of folders that have overlays you can run the following command:
 


### PR DESCRIPTION
also fixed some typos (i.e. `mount -o bind` should be `mount -t bind`)