### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   # Build job
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the Git repository


### PR DESCRIPTION
Potential fix for [https://github.com/Eeems-Org/remarkable.guide/security/code-scanning/1](https://github.com/Eeems-Org/remarkable.guide/security/code-scanning/1)

To fix the problem, explicitly restrict the GITHUB_TOKEN permissions for the `build` job by adding a `permissions` block with the minimal needed access. Since the `build` job checks out code, caches dependencies, installs packages, runs builds, and uploads artifacts, but does not need write access to repository contents, setting `permissions: { contents: read }` suffices. 

This should be added as the first property in the `build` job (just after its name and before `runs-on:`) in `.github/workflows/main.yml`. No other code or import changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
